### PR TITLE
[HDE-888] Add support for additional JDBC writer options

### DIFF
--- a/spark_pipeline_framework/transformers/framework_jdbc_exporter/v1/framework_jdbc_exporter.py
+++ b/spark_pipeline_framework/transformers/framework_jdbc_exporter/v1/framework_jdbc_exporter.py
@@ -15,12 +15,21 @@ class FrameworkJdbcExporter(FrameworkBaseExporter):
     def __init__(
         self, jdbc_url: str, table: str, driver: str, **kwargs: Dict[Any, Any]
     ):
+        options: Dict[str, Any]
+        if "options" in kwargs:
+            options = kwargs.pop("options")
+        else:
+            options = {}
+
         super().__init__(**kwargs)
         assert jdbc_url
         assert table
         assert driver
 
         self.logger = get_logger(__name__)
+
+        self.options: Param = Param(self, "options", "")
+        self._setDefault(options=options)
 
         self.jdbc_url: Param = Param(self, "jdbc_url", "")
         self._setDefault(jdbc_url=jdbc_url)
@@ -31,7 +40,9 @@ class FrameworkJdbcExporter(FrameworkBaseExporter):
         self.driver: Param = Param(self, "driver", "")
         self._setDefault(driver=driver)
 
-        self._set(jdbc_url=jdbc_url, table=table, driver=driver)
+        self._set(
+            jdbc_url=jdbc_url, table=table, driver=driver, options=options
+        )
 
     # noinspection PyPep8Naming,PyMissingOrEmptyDocstring
     def setJdbcUrl(self, value: Param) -> 'FrameworkJdbcExporter':
@@ -63,9 +74,16 @@ class FrameworkJdbcExporter(FrameworkBaseExporter):
     def getFormat(self) -> str:
         return "jdbc"
 
+    def setOptions(self, value: Param) -> 'FrameworkJdbcExporter':
+        self._paramMap[self.options] = value
+        return self
+
     def getOptions(self) -> Dict[str, Any]:
-        return {
+        options: Dict[str, Any] = self.getOrDefault(self.options).copy()
+        parameter_options: Dict[str, Any] = {
             "url": self.getJdbcUrl(),
             "dbtable": self.getTable(),
             "driver": self.getDriver(),
         }
+        options.update(parameter_options)
+        return options

--- a/tests/transformers/framework_jdbc_exporter/v1/test_can_save_via_jdbc.py
+++ b/tests/transformers/framework_jdbc_exporter/v1/test_can_save_via_jdbc.py
@@ -30,3 +30,37 @@ def test_can_save_via_jdbc(spark_session: SparkSession) -> None:
     assert options["driver"] == driver
     assert exporter.getFormat() == "jdbc"
     assert exporter.getMode() == "overwrite"
+
+
+def test_can_specify_additional_writer_options(
+    spark_session: SparkSession
+) -> None:
+    """
+    Because testing against a database is a pain and most of the core transformation logic is in the base exporter,
+    we're only testing that the options and format are correctly being exposed.
+    """
+    # Arrange
+    view = "my_view"
+    jdbc_url = "jdbc:mysql:user@password:host/db:port"
+    table = "my_view_table"
+    driver = "org.driver.FakeDriver"
+    column_types = "Column1 BIGINT, Column2 VARCHAR(1024), Column3 TEXT"
+    options = {"customTableColumntypes": column_types}
+
+    # Act
+    exporter = FrameworkJdbcExporter(
+        view=view,
+        jdbc_url=jdbc_url,
+        table=table,
+        driver=driver,
+        mode=FrameworkJdbcExporter.MODE_OVERWRITE,
+        options=options
+    )
+
+    # Assert
+    options = exporter.getOptions()
+    assert options["url"] == jdbc_url
+    assert options["driver"] == driver
+    assert exporter.getFormat() == "jdbc"
+    assert exporter.getMode() == "overwrite"
+    assert options["customTableColumntypes"] == column_types


### PR DESCRIPTION
For a new pipeline, we need to manually specify column types when writing from Spark to MySQL via JDBC. Spark supports that with via the `createTableColumnTypes` option, but we need to expose that functionality. This PR allows setting arbitrary options as specified here: https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html.

Although URL, table, and driver will primarily be accessed via the `getOptions` function, they are "required options", so I elected to continue to handle them separately when creating the exporter, and only adding them to the options dict when the options are accessed.