### PR TITLE
HHRE-156 minor bug fix for adding an Option either 'dbtable' or 'query'

### DIFF
--- a/spark_pipeline_framework/transformers/framework_jdbc_reader/v1/framework_jdbc_reader.py
+++ b/spark_pipeline_framework/transformers/framework_jdbc_reader/v1/framework_jdbc_reader.py
@@ -76,11 +76,10 @@ class FrameworkJdbcReader(FrameworkTransformer):
         driver: str = self.getDriver()
         view: Optional[str] = self.getView()
         df = (
+            # this execution requires an Option either 'dbtable' or 'query' parameter
             df.sql_ctx.read.format("jdbc")
             .option("url", jdbc_url)
-            .option(
-                "table", query
-            )  # passing "(sql query) table_alias" into "table" parameter.
+            .option("dbtable", query)
             .option("driver", driver)
             .load()
         )


### PR DESCRIPTION
Had an Error when I was trying to use this FrameworkJdbcReader in the helix.pipelines project
`Error	: pyspark.sql.utils.IllegalArgumentException: Option 'dbtable' or 'query' is required.`

thus updating an option to be either dbtable or query,
not sure which one but trying with dbtable first per this article - https://docs.databricks.com/data/data-sources/sql-databases.html#push-down-a-query-to-the-database-engine 